### PR TITLE
Render logic refactor

### DIFF
--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -5,7 +5,7 @@ import UnitSheet from '@/src/components/unit-sheet';
 import styles from './page.module.scss'
 import { DoFArtistConfig } from '@/src/config/artists.config';
 import { useState } from 'react';
-import { IDoFCharacter, IDoFCharacterRenderer, IDoFRenderCharacter, IDoFRenderUnit, IDoFUnit, IKeyMap } from '@/src/models/interfaces';
+import { IDoFCharacter, IDoFCharacterRenderer, IDoFRenderCharacter, IDoFRenderUnit, IDoFUnit, IKeyMap, IRenderCharacterConfig, IRenderItemConfig } from '@/src/models/interfaces';
 import { DoFCharacters } from '@/src/config/characters.config';
 import { DoFChapters } from '@/src/config/chapters.config';
 import OptionSelector from '@/src/components/option-selector';
@@ -13,6 +13,7 @@ import { download, renderCharactersByCountry } from './sheet_export';
 import { useSearchParams } from 'next/navigation'
 import CharacterDetails from '@/src/components/character-details';
 import { DoFRenderCharacter } from '@/src/models/dof-render-character.class';
+import { DoFGeneric } from '@/src/models/dof-render-generic.class';
 
 const defaultRenderValues = {
     prod: { chapter: 6, limit: 14.5 },
@@ -23,169 +24,21 @@ const chapterOptionsLocal = Object.values(DoFChapters).sort((a, b) => a.value - 
 const chapterOptionsProd = chapterOptionsLocal.filter(chapter => chapter.value <= defaultRenderValues.prod.limit);
 
 const isProd = (process.env.NODE_ENV === 'production');
-let useProdOnLocal = false;
-let cachedData: IDoFCharacterRenderer; // we will definitely switch to redux after this
-let currentCharacterCache: IDoFRenderCharacter | undefined;
-let displayRoute = DoFRoute.Both;
 let { chapter: chapterLimit, chapterSelection } = setDisplayValues();
-const { shopkeepers, generics } = cacheStaticUnits();
+let cachedUnits: { characters: DoFRenderCharacter[], shopkeepers: IRenderItemConfig[], generics: IRenderItemConfig[] }; // TODO: move to global state management systems before we make tiermaker 
 
-function cacheStaticUnits() {
-    const cacheItem = (arr: IDoFUnit[], pathType: string) => {
-        return arr.map(item => {
-            const path = getPath(pathType, item.name);
-            return ({ ...item, path, renderOrder: 99 })
-        });
+
+function getCharacters(renderRules: any) {
+    // @ts-ignore
+    const preParseGenerics = (key: string) => DoFCharacters[key].map(unit => (new DoFGeneric(unit, key)).data);
+
+    return {
+        characters: DoFCharacters.characters.map(character => new DoFRenderCharacter(character, renderRules)),
+        shopkeepers: preParseGenerics('shopkeepers'),
+        generics: preParseGenerics('generics'),
     };
-    const shopkeepers: IDoFRenderUnit[] = cacheItem(DoFCharacters.shopkeepers, 'shopkeepers');
-    const generics: IDoFRenderUnit[] = cacheItem(DoFCharacters.generics, 'generics');
-
-    return { shopkeepers, generics };
 }
 
-
-
-function getData(useFull: boolean, bypassSpoiler: boolean): IDoFCharacterRenderer {
-    const config = parseCharacters(useFull ? 99 : chapterLimit, useFull ? DoFRoute.Both : displayRoute, useFull, bypassSpoiler);
-    const getRenderOrder = (item: IDoFRenderUnit) => item.fullSheetRenderOrderOverride ?? item.renderOrder;
-    const sort = (items: any[]) => items.sort((a, b) => getRenderOrder(a) - getRenderOrder(b));
-    if (useFull) {
-        return {
-            characters: [...sort([...config.player, ...config.enemy, ...config.npc]), ...generics, ...shopkeepers]
-        }
-    } else {
-        return {
-            player: sort(config.player),
-            enemy: sort(config.enemy),
-            npc: [...sort(config.npc), ...shopkeepers],
-            generic: generics
-        };
-    }
-}
-
-function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, bypassSpoiler = false) {
-    const config: { [key: string]: any[] } = {
-        [DoFUnitState.Player]: [],
-        [DoFUnitState.Enemy]: [],
-        [DoFUnitState.NPC]: [],
-    };
-    DoFCharacters.characters.forEach(character => {
-        if (character.isSpoiler && !bypassSpoiler) {
-            return;
-        }
-
-        const characterData = new DoFRenderCharacter(character, { bypassSpoiler, useEarliest });
-        characterData.currentChapter = { chapter, route: route === DoFRoute.Musain || route === DoFRoute.Onduris ? route : undefined };
-
-        const results = characterData.data;
-        if(results){
-            config[results.type].push(results);
-        }
-
-        let placement: { value: DoFUnitState, chapter: number } | undefined;
-        if (route === DoFRoute.Musain || route === DoFRoute.Onduris) {
-            placement = getSinglePlacement(route, chapter, character, useEarliest, bypassSpoiler);
-        } else {
-            placement = getDoublePlacement(chapter, character, useEarliest, bypassSpoiler);
-        }
-        if (placement) {
-            let path;
-            path = getPath('characters', character.name);
-
-            const characterItem: IDoFRenderUnit = { ...character, path, renderOrder: placement.chapter };
-
-            if (character.alt) {
-                let characterAlt = character.alt;
-                if (!bypassSpoiler) {
-                    characterAlt = Object.keys(characterAlt).reduce((alts, altName) =>
-                        ((characterAlt[altName].isSpoiler || ((characterAlt[altName].chapter ?? 0) > chapter)) ? alts : { ...alts, [altName]: { ...characterAlt[altName], chapter: undefined } }), {})
-                }
-                characterItem.alt = Object.keys(characterAlt)?.length ? characterAlt : undefined;
-            }
-
-            if (characterItem.alt) {
-                characterItem.altPaths = Object.keys(characterItem.alt).reduce((paths, altName) => ({ ...paths, [altName]: getPath('characters', `${character.name}_${altName}`) }), {});
-            }
-            config[placement.value].push(characterItem);
-        }
-    });
-    return config;
-}
-
-function getSinglePlacement(route: 'musain' | 'onduris', chapter: number, character: IDoFCharacter, useEarliest = false, showSecretPlayable = false) {
-    let routeConfig = character.routeConfig[route] || character.routeConfig.allRoute;
-    const validStates = [];
-    let checkByLatest = (config: number | number[], type: DoFUnitState) => {
-        if (typeof config === 'number') {
-            if (config <= chapter) {
-                validStates.push({ value: type, chapter: config });
-            }
-        } else {
-            let index = -1;
-            while (config[index + 1] <= chapter) {
-                index++;
-            }
-            if (index >= 0) {
-                validStates.push({ value: type, chapter: config[index] });
-            }
-        }
-    }
-
-    if (!routeConfig) {
-        return;
-    }
-
-    if (routeConfig.player != null && routeConfig.player <= chapter && (!character.secret || showSecretPlayable)) {
-        validStates.push({ value: DoFUnitState.Player, chapter: routeConfig.player });
-    }
-    if (routeConfig.enemy != null) {
-        checkByLatest(routeConfig.enemy, DoFUnitState.Enemy);
-    }
-    if (routeConfig.npc != null) {
-        checkByLatest(routeConfig.npc, DoFUnitState.NPC);
-    }
-    if (validStates.length) {
-        validStates.sort((a, b) => {
-            const chapterDiff = b.chapter - a.chapter;
-            if (chapterDiff) {
-                return (useEarliest ? -1 : 1) * chapterDiff;
-            } else {
-                return b.value === DoFUnitState.Player ? 1 :
-                    b.value === DoFUnitState.Enemy && a.value === DoFUnitState.NPC ? 1 : -1;
-            }
-        });
-        return validStates[0];
-    } else {
-        return;
-    }
-}
-
-function getDoublePlacement(chapter: number, character: IDoFCharacter, useEarliest = false, showSecretPlayable = false) {
-    // refactor to be more genericized to accept n routes
-    const placements = ['musain', 'onduris']
-        // @ts-ignore
-        .map(route => getSinglePlacement(route, chapter, character, useEarliest, showSecretPlayable))
-        .filter(placement => placement != null);
-    if (!placements.length) {
-        return undefined;
-    }
-    placements.sort((a, b) => {
-        if (b!.value === a!.value || useEarliest) {
-            return a!.chapter - b!.chapter; // take earlier chapter if both same value for multi placements
-        } else if (b!.value === DoFUnitState.Player) {
-            return 1;
-        } else if (b!.value === DoFUnitState.Enemy) {
-            return a!.value === DoFUnitState.Player ? -1 : 1;
-        } else {
-            return -1;
-        }
-    })
-    return placements[0];
-}
-
-function getPath(type: string, name: string) {
-    return `/mugs/${type}/${name}.png`;
-}
 
 function setDisplayValues(showAllItems: boolean = false) {
     if (showAllItems) {
@@ -194,10 +47,7 @@ function setDisplayValues(showAllItems: boolean = false) {
     return { chapter: defaultRenderValues.prod.chapter, chapterSelection: chapterOptionsProd };
 }
 
-function setVariable(variable: string, value: string) {
-    document.documentElement.style.setProperty(variable, value);
-}
-
+let unitSheetData: IDoFCharacterRenderer;
 let init = false;
 
 
@@ -212,6 +62,10 @@ export default function CharacterPage() {
         currentChapterLimit = chapterLimit;
         chapterSelection = displayValues.chapterSelection;
     }
+    // @ts-ignore
+    if (!cachedUnits) {
+        cachedUnits = getCharacters({ bypassSpoiler: showFullData, useEarliest: false });
+    }
     if (!init) {
         setTimeout(() => {
             if (typeof window !== "undefined") {
@@ -221,73 +75,101 @@ export default function CharacterPage() {
                 });
             }
         }, 0);
+        unitSheetData = getData(chapterLimit, DoFRoute.Both);
     }
-    const [unitSheetData, updateData] = useState(cachedData || getData(showUnsortedFull, showFullData));
-    const [expansionState, setExpansion] = useState({ data: new Map<string, boolean>() });
-    const [currentCharacter, updateCurrentCharacter] = useState(currentCharacterCache);
+
+    let activeCharacter: any;
+
+    const [characterPageState, updateCharacterPage] = useState({
+        chapterLimit,
+        displayRoute: DoFRoute.Both,
+        unitSheetData,
+        expandedPortraits: new Map<string, boolean>(),
+        activeCharacter
+    });
 
     init = true;
 
-    function update() {
-        cachedData = getData(showUnsortedFull, showFullData);
-        updateData(cachedData);
-    }
-
     function changeRoute(route: DoFRoute) {
-        displayRoute = route;
-        let newChapterLimit = chapterLimit;
-        while (newChapterLimit > 0 && displayRoute !== DoFRoute.Both &&
+        let newChapterLimit = characterPageState.chapterLimit;
+        while (newChapterLimit > 0 && route !== DoFRoute.Both &&
             (DoFChapters[newChapterLimit] == null ||
-                (DoFChapters[newChapterLimit].route != null && DoFChapters[chapterLimit].route !== displayRoute)
+                (DoFChapters[newChapterLimit].route != null && DoFChapters[chapterLimit].route !== route)
             )
         ) {
             newChapterLimit -= .5;
         }
-        chapterLimit = newChapterLimit;
-        currentChapterLimit = chapterLimit;
-        update();
-    }
-
-    function toggleProd() {
-        useProdOnLocal = !useProdOnLocal;
-        const displayValues = setDisplayValues();
-        chapterLimit = Math.min(displayValues.chapter, chapterLimit);
-        currentChapterLimit = chapterLimit;
-        chapterSelection = displayValues.chapterSelection;
-        update();
+        unitSheetData = getData(newChapterLimit, route);
+        updateCharacterPage({ ...characterPageState, chapterLimit: newChapterLimit, displayRoute: route, unitSheetData });
     }
 
     function chapterSelect(value: string) {
         const chapter = parseFloat(value);
-        chapterLimit = chapter;
-        currentChapterLimit = chapterLimit;
-        update();
+        const newChapterLimit = chapter;
+        unitSheetData = getData(newChapterLimit, characterPageState.displayRoute);
+        updateCharacterPage({ ...characterPageState, chapterLimit: newChapterLimit, unitSheetData })
     }
 
-    function renderByCountry() {
-        const result = renderCharactersByCountry(unitSheetData);
-        download(result);
+
+    function getData(chapter: number, route: string): any {
+        const useFull = false; // do later
+        const config = parseCharacters(useFull ? 99 : chapter, useFull ? DoFRoute.Both : route);
+        const getRenderOrder = (item: IDoFRenderUnit) => item.renderOrder;
+        const sort = (items: any[]) => items.sort((a, b) => getRenderOrder(a) - getRenderOrder(b));
+        const { shopkeepers, generics } = cachedUnits;
+        if (useFull) {
+            return {
+                characters: [...sort([...config.player, ...config.enemy, ...config.npc]), ...generics, ...shopkeepers]
+            }
+        } else {
+            return {
+                player: sort(config.player),
+                enemy: sort(config.enemy),
+                npc: [...sort(config.npc), ...shopkeepers],
+                generic: generics
+            };
+        }
+    }
+
+    function parseCharacters(chapter: number, route: string) {
+        const baseConfig: { [key: string]: any[] } = {
+            [DoFUnitState.Player]: [],
+            [DoFUnitState.Enemy]: [],
+            [DoFUnitState.NPC]: [],
+        };
+        return cachedUnits.characters.reduce((config, character) => {
+            character.currentChapter = { chapter, route: route === DoFRoute.Musain || route === DoFRoute.Onduris ? route : undefined };
+            const results = character.data;
+            if (results) {
+                config[results.type].push(results);
+            }
+            return config;
+        },
+            baseConfig
+        );
     }
 
     function toggleCharacter(name: string) {
         return function () {
-            expansionState.data.set(name, !expansionState.data.get(name));
-            setExpansion({ data: expansionState.data });
+            characterPageState.expandedPortraits.set(name, !characterPageState.expandedPortraits.get(name));
+            updateCharacterPage({ ...characterPageState, expandedPortraits: characterPageState.expandedPortraits });
         }
     }
 
-    function getClickFunction(characterData: IDoFRenderUnit, characterState: DoFUnitState) {
-        if (characterState === DoFUnitState.Player) {
-            return (data: IDoFRenderCharacter) => {
-                currentCharacterCache = data;
-                updateCurrentCharacter(currentCharacterCache);
+    function getClickFunction(characterData: IRenderCharacterConfig) {
+        if (characterData.type === DoFUnitState.Player) {
+            return () => {
+                updateCharacterPage({ ...characterPageState, activeCharacter: characterData.unitData });
             }
         }
     }
 
     function clearCharacter() {
-        currentCharacterCache = undefined;
-        updateCurrentCharacter(currentCharacterCache);
+        updateCharacterPage({ ...characterPageState, activeCharacter: undefined });
+    }
+
+    function setVariable(variable: string, value: string) {
+        document.documentElement.style.setProperty(variable, value);
     }
 
     return (
@@ -296,18 +178,18 @@ export default function CharacterPage() {
             {!showUnsortedFull ? <div className={styles.controls}>
                 <div className={styles.control}>
                     <label>Route Select</label>
-                    <OptionSelector options={Object.values(DoFRoute)} selection={displayRoute} onSelect={changeRoute} />
+                    <OptionSelector options={Object.values(DoFRoute)} selection={characterPageState.displayRoute} onSelect={changeRoute} />
                 </div>
                 <div className={styles.control}>
                     <label>Chapter Select</label>
-                    <select name="chapter" onChange={(event) => { chapterSelect(event.target.value) }} value={chapterLimit}>
+                    <select name="chapter" onChange={(event) => { chapterSelect(event.target.value) }} value={characterPageState.chapterLimit}>
                         {
                             chapterSelection.map(chapter => {
-                                if (chapter.route && chapter.route !== displayRoute && displayRoute !== DoFRoute.Both) {
+                                if (chapter.route && chapter.route !== characterPageState.displayRoute && characterPageState.displayRoute !== DoFRoute.Both) {
                                     return ''
                                 } else {
                                     return <option key={chapter.value} value={chapter.value}>
-                                        {chapter.title || chapter.value} {displayRoute === DoFRoute.Both && chapter.route ? `(${chapter.route})` : ''}
+                                        {chapter.title || chapter.value} {characterPageState.displayRoute === DoFRoute.Both && chapter.route ? `(${chapter.route})` : ''}
                                     </option>
                                 }
                             })
@@ -315,14 +197,14 @@ export default function CharacterPage() {
                     </select>
                 </div>
             </div> : ''}
-            {currentCharacter ? <CharacterDetails characterDef={currentCharacter} clear={clearCharacter} experimentalFeatures={showFullData} /> : ''}
-            <UnitSheet data={unitSheetData} expansionState={expansionState.data} toggleCharacter={toggleCharacter} chapter={currentChapterLimit} getOnClick={getClickFunction} />
-            {
+            {characterPageState.activeCharacter ? <CharacterDetails characterDef={characterPageState.activeCharacter} clear={clearCharacter} experimentalFeatures={showFullData} /> : ''}
+            <UnitSheet data={characterPageState.unitSheetData} expansionState={characterPageState.expandedPortraits} toggleCharacter={toggleCharacter} chapter={currentChapterLimit} getOnClick={getClickFunction} />
+            {/* {
                 !isProd ? <div style={{ width: 'fit-content', margin: '12px auto', textAlign: 'center' }}>
                     {showFullData ? '' : <button style={{ padding: '12px', height: '40px' }} onClick={toggleProd}>Toggle Production Sheet</button>}
                     <button style={{ padding: '12px', height: '40px' }} onClick={renderByCountry}>Render Sheet By Country</button>
                 </div> : ""
-            }
+            } */}
         </main>
     );
 }

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -12,6 +12,7 @@ import OptionSelector from '@/src/components/option-selector';
 import { download, renderCharactersByCountry } from './sheet_export';
 import { useSearchParams } from 'next/navigation'
 import CharacterDetails from '@/src/components/character-details';
+import { DoFRenderCharacter } from '@/src/models/dof-render-character.class';
 
 const defaultRenderValues = {
     prod: { chapter: 6, limit: 14.5 },
@@ -67,10 +68,24 @@ function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, 
         [DoFUnitState.NPC]: [],
     };
 
+    const config2: { [key: string]: any[] } = {
+        [DoFUnitState.Player]: [],
+        [DoFUnitState.Enemy]: [],
+        [DoFUnitState.NPC]: [],
+    };
     DoFCharacters.characters.forEach(character => {
         if (character.isSpoiler && !bypassSpoiler) {
             return;
         }
+
+        const characterData = new DoFRenderCharacter(character, { bypassSpoiler, useEarliest });
+        characterData.currentChapter = { chapter, route: route === DoFRoute.Musain || route === DoFRoute.Onduris ? route : undefined };
+
+        const results = characterData.data;
+        if(results){
+            config2[results.type].push(results);
+        }
+
         let placement: { value: DoFUnitState, chapter: number } | undefined;
         if (route === DoFRoute.Musain || route === DoFRoute.Onduris) {
             placement = getSinglePlacement(route, chapter, character, useEarliest, bypassSpoiler);
@@ -87,7 +102,7 @@ function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, 
                 let characterAlt = character.alt;
                 if (!bypassSpoiler) {
                     characterAlt = Object.keys(characterAlt).reduce((alts, altName) =>
-                     ((characterAlt[altName].isSpoiler || ((characterAlt[altName].chapter ?? 0) > chapter) )? alts : { ...alts, [altName]: { ...characterAlt[altName], chapter: undefined } }), {})
+                        ((characterAlt[altName].isSpoiler || ((characterAlt[altName].chapter ?? 0) > chapter)) ? alts : { ...alts, [altName]: { ...characterAlt[altName], chapter: undefined } }), {})
                 }
                 characterItem.alt = Object.keys(characterAlt)?.length ? characterAlt : undefined;
             }
@@ -99,13 +114,15 @@ function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, 
         }
     });
 
+    console.log(config2);
+
     return config;
 }
 
 function getSinglePlacement(route: 'musain' | 'onduris', chapter: number, character: IDoFCharacter, useEarliest = false, showSecretPlayable = false) {
     let routeConfig = character.routeConfig[route] || character.routeConfig.allRoute;
     const validStates = [];
-    let checkByLatest = (config: number | number[], type: DoFUnitState)=>{
+    let checkByLatest = (config: number | number[], type: DoFUnitState) => {
         if (typeof config === 'number') {
             if (config <= chapter) {
                 validStates.push({ value: type, chapter: config });
@@ -124,7 +141,7 @@ function getSinglePlacement(route: 'musain' | 'onduris', chapter: number, charac
     if (!routeConfig) {
         return;
     }
-    
+
     if (routeConfig.player != null && routeConfig.player <= chapter && (!character.secret || showSecretPlayable)) {
         validStates.push({ value: DoFUnitState.Player, chapter: routeConfig.player });
     }
@@ -201,7 +218,7 @@ export default function CharacterPage() {
         chapterLimit = 99;
         currentChapterLimit = chapterLimit;
         chapterSelection = displayValues.chapterSelection;
-    } 
+    }
     if (!init) {
         setTimeout(() => {
             if (typeof window !== "undefined") {
@@ -275,7 +292,7 @@ export default function CharacterPage() {
         }
     }
 
-    function clearCharacter(){
+    function clearCharacter() {
         currentCharacterCache = undefined;
         updateCurrentCharacter(currentCharacterCache);
     }
@@ -305,7 +322,7 @@ export default function CharacterPage() {
                     </select>
                 </div>
             </div> : ''}
-            {currentCharacter ? <CharacterDetails characterDef={currentCharacter} clear={clearCharacter} experimentalFeatures={showFullData}/> : ''}
+            {currentCharacter ? <CharacterDetails characterDef={currentCharacter} clear={clearCharacter} experimentalFeatures={showFullData} /> : ''}
             <UnitSheet data={unitSheetData} expansionState={expansionState.data} toggleCharacter={toggleCharacter} chapter={currentChapterLimit} getOnClick={getClickFunction} />
             {
                 !isProd ? <div style={{ width: 'fit-content', margin: '12px auto', textAlign: 'center' }}>

--- a/src/app/characters/page.tsx
+++ b/src/app/characters/page.tsx
@@ -43,6 +43,8 @@ function cacheStaticUnits() {
     return { shopkeepers, generics };
 }
 
+
+
 function getData(useFull: boolean, bypassSpoiler: boolean): IDoFCharacterRenderer {
     const config = parseCharacters(useFull ? 99 : chapterLimit, useFull ? DoFRoute.Both : displayRoute, useFull, bypassSpoiler);
     const getRenderOrder = (item: IDoFRenderUnit) => item.fullSheetRenderOrderOverride ?? item.renderOrder;
@@ -62,13 +64,7 @@ function getData(useFull: boolean, bypassSpoiler: boolean): IDoFCharacterRendere
 }
 
 function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, bypassSpoiler = false) {
-    const config: { [key: string]: IDoFRenderUnit[] } = {
-        [DoFUnitState.Player]: [],
-        [DoFUnitState.Enemy]: [],
-        [DoFUnitState.NPC]: [],
-    };
-
-    const config2: { [key: string]: any[] } = {
+    const config: { [key: string]: any[] } = {
         [DoFUnitState.Player]: [],
         [DoFUnitState.Enemy]: [],
         [DoFUnitState.NPC]: [],
@@ -83,7 +79,7 @@ function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, 
 
         const results = characterData.data;
         if(results){
-            config2[results.type].push(results);
+            config[results.type].push(results);
         }
 
         let placement: { value: DoFUnitState, chapter: number } | undefined;
@@ -113,9 +109,6 @@ function parseCharacters(chapter: number, route: DoFRoute, useEarliest = false, 
             config[placement.value].push(characterItem);
         }
     });
-
-    console.log(config2);
-
     return config;
 }
 

--- a/src/components/character-details/index.module.scss
+++ b/src/components/character-details/index.module.scss
@@ -17,7 +17,7 @@
   overflow: hidden;
 }
 
-.tableWrapper{
+.tableWrapper {
   width: 100%;
   max-width: 100%;
   overflow: auto;
@@ -70,9 +70,9 @@
   gap: 6px;
 }
 
-.extendedProfile{
+.extendedProfile {
   list-style: none;
-  li{
+  li {
     margin-bottom: 6px;
   }
 }
@@ -83,14 +83,13 @@
   padding: 12px;
   overflow: auto;
   box-sizing: content-box;
-  min-width: calc(8 * var(--data-size)  + var(--row-label-size));
-  
+  min-width: calc(8 * var(--data-size) + var(--row-label-size));
 }
 
-.growthsHeader1{
+.growthsHeader1 {
   text-shadow: 0 0 5px var(--dof-color1);
 }
-.growthsHeader2{
+.growthsHeader2 {
   text-shadow: 0 0 5px var(--dof-color3);
 }
 .profile,
@@ -115,7 +114,7 @@
   }
 }
 
-.redText{
+.redText {
   color: #e92323;
 }
 .classText {
@@ -152,7 +151,6 @@
   }
 }
 
-
 .sub {
   font-size: 0.8em;
 }
@@ -171,7 +169,7 @@
   }
 }
 
-.selectedTab{
+.selectedTab {
   font-weight: 600;
 }
 
@@ -203,23 +201,23 @@
     }
   }
 }
-.levelControls{
+.levelControls {
   display: flex;
   justify-content: space-between;
   flex-wrap: wrap;
 }
-.blossomWidget{
+.blossomWidget {
   display: flex;
   align-items: center;
   gap: 12px;
 }
-.blossomButton{
+.blossomButton {
   position: relative;
   display: inline-flex;
   align-items: center;
   gap: 3px;
   order: 2;
-  .plus{
+  .plus {
     position: absolute;
     top: -2px;
     right: -2px;
@@ -227,18 +225,25 @@
     border-radius: 100%;
     width: 14px;
     height: 14px;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+  &:hover {
+    .plus {
+      opacity: 1;
+    }
   }
 }
-.blossomItem{
+.blossomItem {
   height: 32px;
   display: inline-flex;
   background-color: var(--dof-color1);
   padding: 3px 6px;
   border-radius: 3px;
   align-items: center;
-  gap: 3px; 
+  gap: 3px;
   order: 1;
-  input{
+  input {
     height: 100%;
     width: 30px;
     border: 0;
@@ -246,19 +251,19 @@
     padding: 2px 0 0;
   }
 }
-button.removeBlossom{
+button.removeBlossom {
   position: relative;
   display: flex;
   width: 20px;
   height: 20px;
   align-items: center;
   justify-content: center;
-  svg{
+  svg {
     position: relative;
     z-index: 2;
   }
-  &::after{
-    content: '';
+  &::after {
+    content: "";
     position: absolute;
     top: 0;
     left: 0;
@@ -300,15 +305,15 @@ button.removeBlossom{
     flex-direction: row;
     gap: 12px;
   }
-  .dataContent{
+  .dataContent {
     min-width: unset;
   }
 }
 @media screen and (max-width: 600px) {
-  .levelControls{
+  .levelControls {
     margin-bottom: 12px;
   }
-  .characterDetails{
+  .characterDetails {
     --data-size: 35px;
     --row-header-size: 45px;
   }
@@ -325,24 +330,24 @@ button.removeBlossom{
 }
 
 @media screen and (max-width: 400px) {
-  .levelControls{
+  .levelControls {
     flex-direction: column;
     align-items: center;
   }
-  .blossomWidget{
+  .blossomWidget {
     flex-direction: column;
-    *{
+    * {
       order: unset;
     }
   }
 }
 
-.footer{
+.footer {
   border-top: 1px solid var(--dof-color3);
   padding-top: 12px;
   display: flex;
   justify-content: flex-end;
-  label{
-    font-size: .8em;
+  label {
+    font-size: 0.8em;
   }
 }

--- a/src/components/unit-sheet-sprite/index.tsx
+++ b/src/components/unit-sheet-sprite/index.tsx
@@ -1,11 +1,11 @@
-import { IDoFRenderUnit, IDoFUnit, IRenderUnit } from "@/src/models/interfaces";
+import { IDoFRenderUnit, IDoFUnit, IRenderItem, IRenderUnit } from "@/src/models/interfaces";
 
 import styles from './index.module.scss';
 import { DoFArtistConfig } from "@/src/config/artists.config";
 import { DoFUnitState } from "@/src/models/enums";
 export default function UnitSheetSprite({ type, characterDef, expanded, onExpand, onCharacterClick }: {
-    type: DoFUnitState, characterDef: IDoFRenderUnit, expanded?: boolean, onExpand?: () => void,
-    onCharacterClick?: (characterRendered: IRenderUnit) => void
+    type: DoFUnitState, characterDef: IRenderItem, expanded?: boolean, onExpand?: () => void,
+    onCharacterClick?: () => void
 }) {
     return (<div className={styles.wrapper}>
         <div className={`
@@ -18,6 +18,7 @@ export default function UnitSheetSprite({ type, characterDef, expanded, onExpand
                     <div className={styles.label}>Artists:</div>
                     <ul>
                         {characterDef.artists.map(artist => (
+                            // @ts-ignore
                             <li key={artist}>{DoFArtistConfig[artist].name}</li>
                         ))}
                     </ul>
@@ -42,7 +43,7 @@ export default function UnitSheetSprite({ type, characterDef, expanded, onExpand
                     
 
                 if (onCharacterClick) {
-                    return <button className={'button-wrapper'} onClick={()=>onCharacterClick(characterDef)}>{sprite}</button>
+                    return <button className={'button-wrapper'} onClick={onCharacterClick}>{sprite}</button>
                 } else {
                     return sprite;
                 }

--- a/src/components/unit-sheet/index.tsx
+++ b/src/components/unit-sheet/index.tsx
@@ -5,7 +5,6 @@ import styles from './index.module.scss'
 import { IDoFCharacterRenderer, IDoFRenderUnit, IDoFUnit } from '@/src/models/interfaces';
 import { DoFArtist, DoFUnitState } from '@/src/models/enums';
 import { DoFArtistConfig } from '@/src/config/artists.config';
-import { useState } from 'react';
 
 export default function UnitSheet({ data, chapter, expansionState, toggleCharacter, getOnClick }: {
     data: IDoFCharacterRenderer, chapter: number, expansionState: Map<string, boolean>, toggleCharacter: (name: string) => () => void, getOnClick?: (character: any, state: any) => ((data: any) => void) | undefined

--- a/src/components/unit-sheet/index.tsx
+++ b/src/components/unit-sheet/index.tsx
@@ -2,12 +2,12 @@
 
 import UnitSheetSprite from '../../components/unit-sheet-sprite';
 import styles from './index.module.scss'
-import { IDoFCharacterRenderer, IDoFRenderUnit, IDoFUnit } from '@/src/models/interfaces';
+import { IDoFCharacterRenderer, IDoFRenderUnit, IDoFUnit, IRenderCharacterConfig, IRenderItemConfig } from '@/src/models/interfaces';
 import { DoFArtist, DoFUnitState } from '@/src/models/enums';
 import { DoFArtistConfig } from '@/src/config/artists.config';
 
 export default function UnitSheet({ data, chapter, expansionState, toggleCharacter, getOnClick }: {
-    data: IDoFCharacterRenderer, chapter: number, expansionState: Map<string, boolean>, toggleCharacter: (name: string) => () => void, getOnClick?: (character: any, state: any) => ((data: any) => void) | undefined
+    data: IDoFCharacterRenderer, chapter: number, expansionState: Map<string, boolean>, toggleCharacter: (name: string) => () => void, getOnClick?: (character: any, state: any) => (() => void) | undefined
 }) {
     const sections = Object.keys(data) as DoFUnitState[];
     const artists = Object.values(DoFArtist);
@@ -22,54 +22,19 @@ export default function UnitSheet({ data, chapter, expansionState, toggleCharact
                     <section key={section} className={`${styles.container} ${styles.spritesheet}`}>
                         <h2>{section}</h2>
                         {
-                            data[section]?.map((character: IDoFRenderUnit) => {
+                            data[section]?.map((character: IRenderItemConfig) => {
                                 const onClickFcn = getOnClick? getOnClick(character, section): undefined;
-                                if (!character.alt) {
-                                    return <UnitSheetSprite key={character.name} type={section} characterDef={character} onCharacterClick={onClickFcn} />
+                                if (!character.alts?.length) {
+                                    return <UnitSheetSprite key={character.default.name} type={section} characterDef={character.default} onCharacterClick={onClickFcn} />
                                 } else {
-                                    const alts = Object.entries(character.alt);
-                                    const validAlts = alts.filter(([, alt]) => !alt.chapter || alt.chapter <= chapter);
-                                    const toggleFcn = validAlts.length ? toggleCharacter(character.name) : undefined;
-                                    let conditionalPortrait: string | undefined;
-                                    let conditionalOGName: string | undefined;
-                                    if ((character.conditional && section !== DoFUnitState.Generic)) {
-                                        let conditionalConfig = character.conditional[section] ??
-                                            ((character.conditional?.chapter?.chapter ?? -1) <= chapter) ? character.conditional?.chapter : null;
-                                        if (conditionalConfig) {
-                                            conditionalPortrait = conditionalConfig.swapPortrait;
-                                            conditionalOGName = conditionalConfig.ogPortraitName;
-                                        }
-                                    }
-                                    let characterData;
-                                    if (conditionalPortrait) {
-                                        const alt = character.alt[conditionalPortrait];
-                                        characterData = {
-                                            ...character,
-                                            name: `${character.name}_${conditionalPortrait}`,
-                                            displayName: character.displayName || character.name,
-                                            artists: alt.artists,
-                                            path: character!.altPaths![conditionalPortrait]
-                                        };
-                                    } else {
-                                        characterData = character;
-                                    }
-                                    const baseItem = <UnitSheetSprite key={character.name} type={section} characterDef={characterData} expanded={expansionState.get(character.name)} onExpand={toggleFcn} onCharacterClick={onClickFcn} />;
+                                    const toggleFcn = toggleCharacter(character.name);
+                                    const baseItem = <UnitSheetSprite key={character.default.name} type={section} characterDef={character.default} expanded={expansionState.get(character.name)} onExpand={toggleFcn} onCharacterClick={onClickFcn} />;
                                     if (expansionState.get(character.name)) {
-                                        let conditionalItem;
-                                        if (conditionalPortrait) {
-                                            conditionalItem = <UnitSheetSprite key={`${character.name}_original`} type={section} characterDef={{ ...character, displayName: conditionalOGName }} />
-                                        }
                                         return <>
                                             {baseItem}
-                                            {conditionalItem}
-                                            {validAlts.map(([altName, alt]) => {
-                                                if (altName === conditionalPortrait) {
-                                                    return '';
-                                                }
-                                                const displayName = `${character.displayName || character.name} ${alt.displayName || altName}`
-                                                const name = `${character.name}_${altName}`;
-                                                const altData = { ...character, name, displayName, artists: alt.artists, path: character!.altPaths![altName] };
-                                                return <UnitSheetSprite key={`${character.name}_${altName}`} type={section} characterDef={altData} />
+                                            {character.alts.map((alt) => {
+                                                const name = `${character.name}_${alt.name}`;
+                                                return <UnitSheetSprite key={`${character.name}_${alt.name}`} type={section} characterDef={alt} />
                                             })}
                                         </>
                                     } else {

--- a/src/models/dof-render-character.class.ts
+++ b/src/models/dof-render-character.class.ts
@@ -3,10 +3,10 @@ import { IDoFCharacter } from "./dream-of-five.interfaces";
 import { RenderCharacter } from "./render-character.class";
 
 export class DoFRenderCharacter extends RenderCharacter {
-    constructor(character: IDoFCharacter, renderRules: any) {
+    constructor(private dofCharacter: IDoFCharacter, private rules: any) {
         const getPath = (name: string) => {
             return `/mugs/characters/${name}.png`;
         }
-        super(character, getPath, renderRules);
+        super(dofCharacter, getPath, rules);
     }
 } 

--- a/src/models/dof-render-character.class.ts
+++ b/src/models/dof-render-character.class.ts
@@ -1,0 +1,12 @@
+
+import { IDoFCharacter } from "./dream-of-five.interfaces";
+import { RenderCharacter } from "./render-character.class";
+
+export class DoFRenderCharacter extends RenderCharacter {
+    constructor(character: IDoFCharacter, renderRules: any) {
+        const getPath = (name: string) => {
+            return `/mugs/characters/${name}.png`;
+        }
+        super(character, getPath, renderRules);
+    }
+} 

--- a/src/models/dof-render-generic.class.ts
+++ b/src/models/dof-render-generic.class.ts
@@ -1,0 +1,11 @@
+import { IDoFUnit } from "./dream-of-five.interfaces";
+import { RenderUnit } from "./render-unit.class";
+
+export class DoFGeneric extends RenderUnit {
+    constructor(private generic: IDoFUnit, private section: string) {
+        const getPath = (name: string) => {
+            return `/mugs/${section}/${name}.png`;
+        }
+        super(generic, getPath);
+    }
+}

--- a/src/models/dream-of-five.interfaces.ts
+++ b/src/models/dream-of-five.interfaces.ts
@@ -1,5 +1,5 @@
 import { DoFArtist, DoFClasses, DoFNationality } from "./enums";
-import { IAltConfig, IRenderContent, IRenderUnit, IRouteConfig, IUnit } from "./spritesheet.interfaces";
+import { IAltConfig, IRenderCharacterConfig, IRenderContent, IRenderItemConfig, IRenderUnit, IRouteConfig, IUnit } from "./spritesheet.interfaces";
 
 export interface IDoFUnit extends IUnit {
     artists: DoFArtist[];
@@ -46,9 +46,9 @@ export interface IDoFCharacterConfigs {
 };
 
 export type IDoFCharacterRenderer = {
-    [key: string]: IDoFRenderUnit[]
+    [key: string]: IRenderItemConfig[]
 } & {
-    player?: IDoFRenderCharacter[],
-    enemy?: IDoFRenderCharacter[],
+    player?: IRenderCharacterConfig[],
+    enemy?: IRenderCharacterConfig[],
 };
 

--- a/src/models/dream-of-five.interfaces.ts
+++ b/src/models/dream-of-five.interfaces.ts
@@ -17,11 +17,11 @@ export interface IDoFAlt extends IAltConfig {
 
 export interface IDoFCharacter extends IDoFUnit {
     routeConfig: IRouteConfig
-    secret?: boolean,    
+    secret?: boolean,
     altNames?: string[], // subtitles to profile names, displayed as secondary
     // overrides all other instances of name displays for the profile, otherwise if you want the same name on the sheet and profile use displayName
     // this is mostly to write in last names to display
-    profileName?: string,  
+    profileName?: string,
     //extendedProfile
     height?: number,
     age?: number,
@@ -36,8 +36,8 @@ export interface IDoFStats {
     [stat: string]: number
 }
 
-export interface IDoFRenderUnit extends IDoFUnit, IRenderContent {}
-export interface IDoFRenderCharacter extends IDoFRenderUnit, IDoFCharacter { };
+export interface IDoFRenderUnit extends IDoFUnit, IRenderContent { }
+export interface IDoFRenderCharacter extends IDoFCharacter, IRenderContent { };
 
 export interface IDoFCharacterConfigs {
     characters: IDoFCharacter[];

--- a/src/models/render-character.class.ts
+++ b/src/models/render-character.class.ts
@@ -1,0 +1,213 @@
+import { IUnit } from "./spritesheet.interfaces";
+
+// TODO: have a DoFCharacter class that extends this
+
+export class RenderCharacter {
+    constructor(
+        private character: IUnit,
+        private getPath: (name: string) => string,
+        private renderRules: { bypassSpoiler?: boolean, useEarliest?: boolean } = {}
+    ) {
+        this.urls = {
+            default: getPath(character.name),
+            alts: character.alt ? Object.keys(character.alt).reduce((c, k) => ({ ...c, [k]: getPath(`${character.name}_${k}`) }), {}) : {}
+        };
+    }
+
+    // private chapterData: { chapter: number, route: string } | undefined;
+    // private placement: { value: string, chapter: number } | undefined;
+    // private parsedCharacter?: IRenderUnit;
+    private renderData?: any;
+
+    private urls: {
+        default: string,
+        alts: { [key: string]: string }
+    };
+
+    set currentChapter(data: { chapter: number, route?: string } | undefined) {
+
+        // this.chapterData = data;
+        const placement = data ? this.getCharacterPlacement(data) : undefined;
+        const parsedCharacter = placement ? this.parseCharacter(placement) : undefined;
+        if (parsedCharacter && data && placement) {
+            this.renderData = this.getRenderItems(parsedCharacter, data.chapter, placement)
+        }
+    }
+
+    get data() {
+        return this.renderData;
+    }
+
+    private getCharacterPlacement(chapterData: { chapter: number, route?: string }) {
+        const { bypassSpoiler, useEarliest } = this.renderRules;
+        const { chapter, route } = chapterData;
+        if (this.character.isSpoiler && !bypassSpoiler) {
+            return;
+        }
+        let placement: { value: string, chapter: number } | undefined;
+        if (chapterData.route == null && this.character.routeConfig && Object.keys(this.character.routeConfig).length > 1) {
+            placement = this.getAllPlacement(chapter, this.character, useEarliest, bypassSpoiler);
+        } else {
+            placement = this.getSinglePlacement(route, chapter, this.character, useEarliest, bypassSpoiler);
+        }
+        return placement;
+    }
+
+    private getSinglePlacement(route: string | undefined | null, chapter: number, character: IUnit, useEarliest = false, showSecretPlayable = false) {
+        if (!character.routeConfig) {
+            return;
+        }
+        let routeConfig;
+        if (route) {
+            routeConfig = character.routeConfig[route];
+        } else if (character.routeConfig.allRoute) {
+            routeConfig = character.routeConfig.allRoute;
+
+        } else {
+            const config = Object.values(character.routeConfig);
+            if(config.length){
+                routeConfig = config[0];
+            }
+        }
+        if (!routeConfig) {
+            return;
+        }
+        const validStates = [];
+        let checkByLatest = (config: number | number[], type: string) => {
+            if (typeof config === 'number') {
+                if (config <= chapter) {
+                    validStates.push({ value: type, chapter: config });
+                }
+            } else {
+                let index = -1;
+                while (config[index + 1] <= chapter) {
+                    index++;
+                }
+                if (index >= 0) {
+                    validStates.push({ value: type, chapter: config[index] });
+                }
+            }
+        }
+
+        if (routeConfig.player != null && routeConfig.player <= chapter && (!character.secret || showSecretPlayable)) {
+            validStates.push({ value: 'player', chapter: routeConfig.player });
+        }
+        if (routeConfig.enemy != null) {
+            checkByLatest(routeConfig.enemy, 'enemy');
+        }
+        if (routeConfig.npc != null) {
+            checkByLatest(routeConfig.npc, 'npc');
+        }
+        if (validStates.length) {
+            validStates.sort((a, b) => {
+                const chapterDiff = b.chapter - a.chapter;
+                if (chapterDiff) {
+                    return (useEarliest ? -1 : 1) * chapterDiff;
+                } else {
+                    return b.value === 'player' ? 1 :
+                        b.value === 'enemy' && a.value === 'npc' ? 1 : -1;
+                }
+            });
+            return validStates[0];
+        } else {
+            return;
+        }
+    }
+
+    private getAllPlacement(chapter: number, character: IUnit, useEarliest = false, showSecretPlayable = false) {
+        // refactor to be more genericized to accept n routes
+        const placements = Object.keys(character.routeConfig!)
+            // @ts-ignore
+            .map(route => this.getSinglePlacement(route, chapter, character, useEarliest, showSecretPlayable))
+            .filter(placement => placement != null);
+        if (!placements.length) {
+            return undefined;
+        }
+        placements.sort((a, b) => {
+            if (b!.value === a!.value || useEarliest) {
+                return a!.chapter - b!.chapter; // take earlier chapter if both same value for multi placements
+            } else if (b!.value === 'player') {
+                return 1;
+            } else if (b!.value === 'enemy') {
+                return a!.value === 'npc' ? -1 : 1;
+            } else {
+                return -1;
+            }
+        })
+        return placements[0];
+    }
+
+    private parseCharacter(placement: { value: string, chapter: number }) {
+        const { bypassSpoiler } = this.renderRules;
+        if (placement) {
+            const characterItem: IUnit = { ...this.character };
+            if (this.character.alt) {
+                let characterAlt = { ...this.character.alt };
+                if (!bypassSpoiler) {
+                    characterAlt = Object.keys(this.character.alt).reduce((alts, altName) => (characterAlt[altName].isSpoiler ? alts : { ...alts, [altName]: { ...characterAlt[altName] } }), {})
+                }
+                characterItem.alt = Object.keys(characterAlt)?.length ? characterAlt : undefined;
+            }
+            return characterItem;
+        }
+    }
+
+    private getRenderItems(unit: IUnit, chapter: number, placement: { value: string, chapter: number }) {
+        let defaultDisplay = { name: unit.name, displayName: unit.displayName, path: this.urls.default, artists: unit.artists };
+        let alts;
+        let defaultSwap;
+        // check conditionals
+        // consolidate unit type vs chapter based conditionals and then apply them all
+        // chapter based override unit type based if chapter > placement.chapter, if equal or less then unit type
+        let newDisplayName, swapPortrait: string, ogPortraitName;
+        if (unit.conditional) {
+            let chapterConditionals = unit.conditional.chapter && unit.conditional.chapter.chapter! <= chapter ? unit.conditional.chapter : null;
+            // @ts-ignore
+            let typeConditionals = unit.conditional[placement.value];
+            if (chapterConditionals && typeConditionals) {
+                let primary, secondary;
+                if (chapterConditionals.chapter! > placement.chapter) {
+                    primary = chapterConditionals;
+                    secondary = typeConditionals;
+                } else {
+                    primary = typeConditionals;
+                    secondary = chapterConditionals;
+                }
+                newDisplayName = primary.displayName ?? secondary.displayName;
+                swapPortrait = primary.swapPortrait ?? secondary.swapPortrait;
+                ogPortraitName = primary.ogPortraitName ?? secondary.ogPortraitName;
+            } else if (chapterConditionals || typeConditionals) {
+                let conditionals = chapterConditionals ?? typeConditionals;
+                newDisplayName = conditionals.displayName;
+                swapPortrait = conditionals.swapPortrait;
+                ogPortraitName = conditionals.ogPortraitName;
+            }
+        }
+        // @ts-ignore
+        if (swapPortrait && unit.alt && unit.alt[swapPortrait]) { // ogPortraitName is always configured for swapPortrait otherwise it doesn't do anything
+            const swapItem = unit.alt[swapPortrait];
+            defaultSwap = defaultDisplay;
+            defaultDisplay = { name: swapPortrait, path: this.urls.alts[swapPortrait], artists: swapItem.artists, displayName: swapItem.displayName }
+            defaultSwap.displayName = ogPortraitName ?? defaultSwap.displayName;
+        }
+        if (newDisplayName) {
+            defaultDisplay.displayName = newDisplayName;
+        }
+        if (unit.alt) {
+            alts = Object.entries(unit.alt)
+                .filter(([key, value]) => key != swapPortrait && (!value.chapter || value.chapter <= chapter))
+                .map(([key, value]) => ({ ...value, name: key, path: this.urls.alts[key] }));
+        }
+        if (defaultSwap) {
+            alts = alts ? [defaultSwap, ...alts] : [defaultSwap];
+        }
+        return {
+            renderOrder: placement.chapter,
+            type: placement.value,
+            unitData: { ...unit, path: defaultDisplay.path },
+            defaultDisplay,
+            alts
+        };
+    }
+};
+

--- a/src/models/render-character.class.ts
+++ b/src/models/render-character.class.ts
@@ -5,21 +5,21 @@ import { IUnit } from "./spritesheet.interfaces";
 
 export class RenderCharacter extends RenderUnit {
     constructor(
-        private character: IUnit,
+        private characterInput: IUnit,
         private getPath: (name: string) => string,
         private renderRules: { bypassSpoiler?: boolean, useEarliest?: boolean } = {}
     ) {
-        super(character, getPath);
+        super(characterInput, getPath);
     }
 
     private renderData?: any;
     set currentChapter(data: { chapter: number, route?: string } | undefined) {
-
-        // this.chapterData = data;
         const placement = data ? this.getCharacterPlacement(data) : undefined;
         const parsedCharacter = placement ? this.parseCharacter(placement) : undefined;
         if (parsedCharacter && data && placement) {
             this.renderData = this.getRenderItems(parsedCharacter, data.chapter, placement)
+        } else {
+            this.renderData = undefined;
         }
     }
 
@@ -34,7 +34,10 @@ export class RenderCharacter extends RenderUnit {
             return;
         }
         let placement: { value: string, chapter: number } | undefined;
-        if (chapterData.route == null && this.character.routeConfig && Object.keys(this.character.routeConfig).length > 1) {
+        if (!this.character.routeConfig) {
+            return;
+        }
+        if (chapterData.route == null) {
             placement = this.getAllPlacement(chapter, this.character, useEarliest, bypassSpoiler);
         } else {
             placement = this.getSinglePlacement(route, chapter, this.character, useEarliest, bypassSpoiler);
@@ -43,20 +46,11 @@ export class RenderCharacter extends RenderUnit {
     }
 
     private getSinglePlacement(route: string | undefined | null, chapter: number, character: IUnit, useEarliest = false, showSecretPlayable = false) {
-        if (!character.routeConfig) {
-            return;
-        }
         let routeConfig;
-        if (route) {
+        if (route && character.routeConfig[route]) {
             routeConfig = character.routeConfig[route];
         } else if (character.routeConfig.allRoute) {
             routeConfig = character.routeConfig.allRoute;
-
-        } else {
-            const config = Object.values(character.routeConfig);
-            if (config.length) {
-                routeConfig = config[0];
-            }
         }
         if (!routeConfig) {
             return;
@@ -178,6 +172,7 @@ export class RenderCharacter extends RenderUnit {
             defaultSwap = defaultDisplay;
             defaultDisplay = { name: swapPortrait, path: this.urls.alts[swapPortrait], artists: swapItem.artists, displayName: swapItem.displayName }
             defaultSwap.displayName = ogPortraitName ?? defaultSwap.displayName;
+            newDisplayName  = newDisplayName ?? unit.displayName ?? unit.name;
         }
         if (newDisplayName) {
             defaultDisplay.displayName = newDisplayName;
@@ -185,16 +180,17 @@ export class RenderCharacter extends RenderUnit {
         if (unit.alt) {
             alts = Object.entries(unit.alt)
                 .filter(([key, value]) => key != swapPortrait && (!value.chapter || value.chapter <= chapter))
-                .map(([key, value]) => ({ ...value, name: key, path: this.urls.alts[key] }));
+                .map(([key, value]) => ({ ...value, name: key, path: this.urls.alts[key], displayName:`${unit.displayName} ${value.displayName}` }));
         }
         if (defaultSwap) {
             alts = alts ? [defaultSwap, ...alts] : [defaultSwap];
         }
         return {
+            name: this.character.name,
             renderOrder: placement.chapter,
             type: placement.value,
             unitData: { ...unit, path: defaultDisplay.path },
-            defaultDisplay,
+            default: defaultDisplay,
             alts
         };
     }

--- a/src/models/render-character.class.ts
+++ b/src/models/render-character.class.ts
@@ -1,29 +1,18 @@
+import { RenderUnit } from "./render-unit.class";
 import { IUnit } from "./spritesheet.interfaces";
 
 // TODO: have a DoFCharacter class that extends this
 
-export class RenderCharacter {
+export class RenderCharacter extends RenderUnit {
     constructor(
         private character: IUnit,
         private getPath: (name: string) => string,
         private renderRules: { bypassSpoiler?: boolean, useEarliest?: boolean } = {}
     ) {
-        this.urls = {
-            default: getPath(character.name),
-            alts: character.alt ? Object.keys(character.alt).reduce((c, k) => ({ ...c, [k]: getPath(`${character.name}_${k}`) }), {}) : {}
-        };
+        super(character, getPath);
     }
 
-    // private chapterData: { chapter: number, route: string } | undefined;
-    // private placement: { value: string, chapter: number } | undefined;
-    // private parsedCharacter?: IRenderUnit;
     private renderData?: any;
-
-    private urls: {
-        default: string,
-        alts: { [key: string]: string }
-    };
-
     set currentChapter(data: { chapter: number, route?: string } | undefined) {
 
         // this.chapterData = data;
@@ -65,7 +54,7 @@ export class RenderCharacter {
 
         } else {
             const config = Object.values(character.routeConfig);
-            if(config.length){
+            if (config.length) {
                 routeConfig = config[0];
             }
         }

--- a/src/models/render-unit.class.ts
+++ b/src/models/render-unit.class.ts
@@ -1,0 +1,25 @@
+import { IRenderItemConfig, IUnit } from "./spritesheet.interfaces";
+
+export class RenderUnit {
+
+    constructor(private unit: IUnit, private pathFcn: (name: string) => string) {
+        this.urls = {
+            default: pathFcn(unit.name),
+            alts: unit.alt ? Object.keys(unit.alt).reduce((c, k) => ({ ...c, [k]: pathFcn(`${unit.name}_${k}`) }), {}) : {}
+        };
+    }
+
+    urls: {
+        default: string,
+        alts: { [key: string]: string }
+    };
+
+    get data(): IRenderItemConfig {
+        return {
+            renderOrder: Number.MAX_SAFE_INTEGER,
+            type: 'unit',
+            default: { ...this.unit, path: this.urls.default },
+            alts: this.unit.alt ? Object.entries(this.unit.alt).map(([key, value]) => ({ ...value, name: key, path: this.urls.alts[key] })) : undefined
+        };
+    }
+}

--- a/src/models/render-unit.class.ts
+++ b/src/models/render-unit.class.ts
@@ -7,8 +7,15 @@ export class RenderUnit {
             default: pathFcn(unit.name),
             alts: unit.alt ? Object.keys(unit.alt).reduce((c, k) => ({ ...c, [k]: pathFcn(`${unit.name}_${k}`) }), {}) : {}
         };
+        this.character = { ...this.unit };
+        this.character.displayName = this.character.displayName ?? this.capitalize(this.character.name);
+        const unitAlts = this.unit.alt;
+        if (unitAlts) {
+            this.character.alt = Object.keys(unitAlts).reduce((alts, key) => ({ ...alts, [key]: { ...unitAlts[key], displayName: unitAlts[key].displayName ?? this.capitalize(key) } }), {});
+        }
     }
 
+    character: IUnit;
     urls: {
         default: string,
         alts: { [key: string]: string }
@@ -16,10 +23,15 @@ export class RenderUnit {
 
     get data(): IRenderItemConfig {
         return {
+            name: this.unit.name,
             renderOrder: Number.MAX_SAFE_INTEGER,
             type: 'unit',
             default: { ...this.unit, path: this.urls.default },
             alts: this.unit.alt ? Object.entries(this.unit.alt).map(([key, value]) => ({ ...value, name: key, path: this.urls.alts[key] })) : undefined
         };
+    }
+
+    private capitalize(str: string) {
+        return str.charAt(0).toUpperCase() + str.slice(1);
     }
 }

--- a/src/models/spritesheet.interfaces.ts
+++ b/src/models/spritesheet.interfaces.ts
@@ -11,7 +11,9 @@ export interface IUnit {
         npc?: IConditional;
         chapter?: IConditional;
     },
+    routeConfig?: any,
     isSpoiler?: boolean;
+    secret?: boolean;
     fullSheetRenderOrderOverride?: number
 }
 
@@ -19,11 +21,6 @@ export interface IRenderContent {
     path: string;
     altPaths?: {
         [key: string]: string;
-    },
-    conditionalName?: { // used over displayName
-        player?: string;
-        enemy?: string;
-        npc?: string;
     },
     renderOrder: number,
 }

--- a/src/models/spritesheet.interfaces.ts
+++ b/src/models/spritesheet.interfaces.ts
@@ -5,6 +5,7 @@ export interface IRenderItem {
     path: string
 };
 export interface IRenderItemConfig {
+    name: string,
     default: IRenderItem;
     alts?: IRenderItem[];
     renderOrder: number;
@@ -12,7 +13,7 @@ export interface IRenderItemConfig {
 };
 
 export interface IRenderCharacterConfig extends IRenderItemConfig{
-    unit: any
+    unitData: any
 };
 export interface IUnit {
     name: string;

--- a/src/models/spritesheet.interfaces.ts
+++ b/src/models/spritesheet.interfaces.ts
@@ -1,3 +1,19 @@
+export interface IRenderItem {
+    name: string,
+    artists: string[],
+    displayName?: string,
+    path: string
+};
+export interface IRenderItemConfig {
+    default: IRenderItem;
+    alts?: IRenderItem[];
+    renderOrder: number;
+    type: string;
+};
+
+export interface IRenderCharacterConfig extends IRenderItemConfig{
+    unit: any
+};
 export interface IUnit {
     name: string;
     artists: string[];


### PR DESCRIPTION
refactors all the data-massaging/placement calculations aspect into new classes that genericizes the fields so that stuff can be used for non-dof projects down the line, and also keeps all the text changing + conditional portrait swapping + alt displaying logic all in one place. removes a lot of the logic previously in components so it is much more organized now.